### PR TITLE
Fix permissions not being registered

### DIFF
--- a/src/main/java/com/lenis0012/bukkit/marriage2/commands/Command.java
+++ b/src/main/java/com/lenis0012/bukkit/marriage2/commands/Command.java
@@ -32,7 +32,7 @@ public abstract class Command {
     public Command(Marriage marriage, String command, String... aliases) {
         this.marriage = marriage;
         this.aliases = Lists.asList(command, aliases).toArray(new String[0]);
-        if(aliases.length > 0) {
+        if(this.aliases.length > 0) {
             this.permission = Permissions.getByNode("marry." + aliases[0]);
         }
     }


### PR DESCRIPTION
Small typo prevents permissions from being registered, meaning they are never checked for.