### PR TITLE
Reload messages on /marry reload

### DIFF
--- a/src/main/java/com/lenis0012/bukkit/marriage2/internal/MarriageCore.java
+++ b/src/main/java/com/lenis0012/bukkit/marriage2/internal/MarriageCore.java
@@ -85,6 +85,7 @@ public class MarriageCore extends MarriageBase {
     }
 
     public void reloadSettings() {
+        Message.reloadAll(this);
         for(String identifier : Settings.GENDER_OPTIONS.value().getKeys(false)) {
             Genders.removeGenderOption(identifier);
         }


### PR DESCRIPTION
This tiny PR reloads the `messages.yml` file when using /marry reload. Currently, the server has to be rebooted for the file to be updated and the changes reflected in-game.
![image](https://user-images.githubusercontent.com/71913030/221428616-350ed91c-7a4f-41a7-bb0c-8f81a3c8e6d1.png)
