### PR TITLE
Skip sending empty messages

### DIFF
--- a/src/main/java/com/lenis0012/bukkit/marriage2/commands/Command.java
+++ b/src/main/java/com/lenis0012/bukkit/marriage2/commands/Command.java
@@ -104,6 +104,7 @@ public abstract class Command {
     }
 
     protected void reply(CommandSender sender, String message, Object... args) {
+        if (message.isEmpty()) return;
         message = ChatColor.translateAlternateColorCodes('&', String.format(message, args));
         sender.sendMessage(message);
     }
@@ -113,6 +114,7 @@ public abstract class Command {
     }
 
     protected void broadcast(String message, Object... args) {
+        if (message.isEmpty()) return;
         message = ChatColor.translateAlternateColorCodes('&', String.format(message, args));
         Bukkit.broadcastMessage(message);
     }

--- a/src/main/java/com/lenis0012/bukkit/marriage2/config/Message.java
+++ b/src/main/java/com/lenis0012/bukkit/marriage2/config/Message.java
@@ -100,6 +100,7 @@ public enum Message {
     }
 
     public void send(CommandSender player, Object... params) {
+        if (message.isEmpty()) return;
         player.sendMessage(ChatColor.translateAlternateColorCodes('&', String.format(message, params)));
     }
 


### PR DESCRIPTION
This PR allows users to make messages in the `messages.yml` file blank, which will now skip sending the message altogether. The current behavior just sends an empty line. Let me know if I missed anywhere else where messages are sent.